### PR TITLE
C96向けサイト更新 (ゲーム集)

### DIFF
--- a/toyogy.html
+++ b/toyogy.html
@@ -110,6 +110,18 @@
 		</dl>
 
 		<h2>ゲーム集</h2>
+		<h3>ゲーム箱!! vol.8</h3>
+		<ul>
+			<li>Tofu on Fire (わちゃわちゃ2Dシューティング)</li>
+			<li>つながーる! (横スクロール物理アクション)</li>
+		</ul>
+		<iframe width="560" height="315" src="https://www.youtube.com/embed/SAaV-KpFvVw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+		<dl>
+			<dt>発行日</dt>
+			<dd>2019/08/12</dd>
+			<dt>初出</dt>
+			<dd>コミックマーケット96 4日目</dd>
+		</dl>
 		<h3>ゲーム箱!! vol.7</h3>
 		<ul>
 			<li>Charge 2018 (4人対戦カーバトル)</li>
@@ -124,6 +136,7 @@
 			<dd>コミックマーケット95 2日目</dd>
 		</dl>
 		<h3>ゲーム箱!! vol.6</h3>
+		<a href="https://drive.google.com/open?id=1qbcl58HtZtAAQV5NIJsWfuqzn4KW9n8S">ゲームダウンロードはこちら</a><br>
 		<ul>
 			<li>Chime Extreme (パズルゲーム)</li>
 			<li>白い空間シミュレータ (異世界転生ゲーム)</li>


### PR DESCRIPTION
コミックマーケット96に向けて、ゲーム集の情報を追記しました。
- 広報活動のページに、vol.8(新作)の紹介を追加しました
- 同ページに、vol.6(過去作)のダウンロードリンクを追加しました
