### PR TITLE
chore(fix): `README.org` のTODOを削除

### DIFF
--- a/.github/README.org
+++ b/.github/README.org
@@ -1,4 +1,3 @@
 * tut-cc.org
 www.tut-cc.org のHTMLです
 githubにpushするたびにWebhookが走りmasterを展開します。
-READMEもwww.tut-cc.org/README.orgで見れる感じなのでそのうちどうにかします。


### PR DESCRIPTION
`README.org` には `www.tut-cc.org` でアクセスできてしまうと書かれていたが、
`/.github/` ディレクトリに移動することで回避した。

fix: Remove todo from README.org

The file `README.org` has moved in `/.github/`, 
so the renderer `jekyll` ignores README.org from the targets.